### PR TITLE
Build against hhvm with failures allow and also build against php 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
 language: php
 
-
 php:
   - 5.4
   - 5.5
+  - 5.6
+  - hhvm
 
+matrix:
+  allow_failures:
+    - php: hhvm
 
 before_script:
   - composer selfupdate


### PR DESCRIPTION
Not really any draw backs with building against hhvm when we allow failures.

Should probably be also building against PHP 5.6.
