### PR TITLE
Add requirement of PHP 5.4+ in composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
         }
     ],
     "require": {
+        "php": ">=5.4.0",
         "phpunit/phpunit": "*"
     },
     "autoload":


### PR DESCRIPTION
Noticed in the .travis.yml that you were only building above PHP5.4 and figured I'd throw the requirement in the composer file as well for good package management =D!
