### PR TITLE
Add the travis CI badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-phpwar
+phpwar [![Build Status](https://secure.travis-ci.org/iannsp/phpwar.png?branch=master)](http://travis-ci.org/iannsp/phpwar)
 ======
 
 Code War php


### PR DESCRIPTION
Before my pull requests I thought all the tests were passing in this project but I've come to find out upon checking the travis page that they weren't.

Figure it is worth while just having the Travis CI badge on the readme
