### PR TITLE
Fixed variable typo in Turn::detach()

### DIFF
--- a/src/Iannsp/PhpWar/Game/Turn.php
+++ b/src/Iannsp/PhpWar/Game/Turn.php
@@ -59,7 +59,7 @@ class Turn implements \Iterator, \Countable, \SplSubject
 
     public function detach(\SplObserver $observer)
     {
-        $this->observers->detach($observers);
+        $this->observers->detach($observer);
     }
 
     public function notify()


### PR DESCRIPTION
Plural variable "observers" is referenced in local scope without declaration. Singular variable "observer" is the sole function argument - given context, I believe this is a fix.
